### PR TITLE
Properly remove overflow data from disk

### DIFF
--- a/src/Data/BTree/Alloc/Class.hs
+++ b/src/Data/BTree/Alloc/Class.hs
@@ -64,4 +64,7 @@ class AllocReaderM m => AllocM m where
     -- | Free an overflow page.
     freeOverflow :: OverflowId -> m ()
 
+    -- | Force delete overflow data from disk.
+    deleteOverflowData :: OverflowId -> m ()
+
 --------------------------------------------------------------------------------

--- a/src/Data/BTree/Alloc/Debug.hs
+++ b/src/Data/BTree/Alloc/Debug.hs
@@ -85,3 +85,4 @@ instance (Functor m, Monad m) => AllocM (DebugT m) where
         return (0, c)
 
     freeOverflow _ = return ()
+    deleteOverflowData _ = return ()


### PR DESCRIPTION
- [ ] includes tests
- [x] ready for review
- [x] reviewed by @hverr

cc: @dfordivam

#### What does this PR do?
This pull request introduces patches to fix issue haskell-haskey/haskey#70.

1. It introduces an interface to properly delete overflow data from disk.
2. It properly marks overflow pages for deletion when overwriting keys with attached overflow pages

#### Where should the reviewer start?
#### How should this be manually tested?
See minimal code examples that isolate the issue in haskell-haskey/haskey#70

#### Any background context you want to provide?
#### What are the relevant tickets?
- haskell-haskey/haskey#70
- haskell-haskey/haskey#71