### PR TITLE
Bump text lower bound to 1.2.1

### DIFF
--- a/haskey-btree.cabal
+++ b/haskey-btree.cabal
@@ -71,7 +71,7 @@ library
     hashable                >=1.2  && <1.3,
     mtl                     >=2.1  && <3,
     semigroups              >=0.12 && <1,
-    text                    >=1.2 && <2,
+    text                    >=1.2.1 && <2,
     transformers            >=0.3  && <1,
     vector                  >=0.10 && <1
 


### PR DESCRIPTION
Bump the lower bound of `text` to 1.2.1.0, because it is the first version that comes with `Binary` instances for `Text`.

- [ ] includes tests
- [X] ready for review
- [X] reviewed by @hverr

#### How should this be manually tested?
Compile with `cabal new-build -w ghc-7.10.3 --constraint='text==1.2.0.6'` to see that it breaks:

```
Build profile: -w ghc-7.10.3 -O1
In order, the following will be built (use -v for more details):
 - haskey-btree-0.3.0.0 (lib) (first run)
Preprocessing library for haskey-btree-0.3.0.0..
Building library for haskey-btree-0.3.0.0..
[ 5 of 25] Compiling Data.BTree.Primitives.Value ( src/Data/BTree/Primitives/Value.hs, /home/steve/Code/haskey-btree/dist-newstyle/build/x86_64-linux/ghc-7.10.3/haskey-btree-0.3.0.0/build/Data/BTree/Primitives/Value.o )

src/Data/BTree/Primitives/Value.hs:38:10:
    No instance for (Binary Text)
      arising from the superclasses of an instance declaration
    In the instance declaration for ‘Value Text’
```

and then compile with text-1.2.1.0 and see that it compiles.
